### PR TITLE
Updating go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Dabz/ccloudexporter
+module github.com/Swiggy/ccloudexporter
 
 go 1.14
 


### PR DESCRIPTION
Required change essential while building Dockerfile
-- module declares its path as: github.com/Dabz/ccloudexporter
	        but was required as: github.com/Swiggy/ccloudexporter