### PR TITLE
Reverting to 1000 from 10000

### DIFF
--- a/cmd/internal/collector/query.go
+++ b/cmd/internal/collector/query.go
@@ -97,7 +97,7 @@ func BuildQuery(metric MetricDescription, cluster string) Query {
 		Filter:      filterHeader,
 		Granularity: Granularity,
 		GroupBy:     groupBy,
-		Limit:       10000,
+		Limit:       1000,
 		Intervals:   []string{fmt.Sprintf("%s/%s", timeFrom.Format(time.RFC3339), Granularity)},
 	}
 }


### PR DESCRIPTION
Limit is imposed by confluent itself, checked with api calls http -v https://api.telemetry.confluent.cloud/v1/metrics/cloud/query.
Currently all the queries are getting 403/422 http status code, because of the same.